### PR TITLE
Dockerfile Misconfiguration: Dependency Confusion

### DIFF
--- a/apps/api-runtime/Dockerfile
+++ b/apps/api-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk
+FROM openjdk:latest
 WORKDIR /app
 COPY ./target/api-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar /app/api-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar
 CMD "java" "-XX:+ExitOnOutOfMemoryError" "-jar" "/app/api-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar"


### PR DESCRIPTION
Retrieving build dependencies using a non-specific version can leave the build system vulnerable to malicious binaries or cause the system to experience unexpected behavior.